### PR TITLE
Fix incorrect frontend plugin version

### DIFF
--- a/charts/backstage/backstage-ansible-bu-values.yaml
+++ b/charts/backstage/backstage-ansible-bu-values.yaml
@@ -68,7 +68,7 @@ global:
       - package: ./dynamic-plugins/dist/backstage-plugin-tech-radar
         disabled: false
       - package: >-
-          http://ansible-plugin-registry.plugin-registries:8080/ansible-plugin-backstage-rhaap-0.0.6.tgz
+          http://ansible-plugin-registry.plugin-registries:8080/ansible-plugin-backstage-rhaap-0.0.5.tgz
         disabled: false
         pluginConfig:
           dynamicPlugins:


### PR DESCRIPTION
I miscommunicated the version change this morning, the bundle version changed to 0.0.6 but the frontend plugin version is still 0.0.5