### PR TITLE
fix: orchestrator backend access to rhdh

### DIFF
--- a/charts/backstage/backstage-rhtap-values.yaml
+++ b/charts/backstage/backstage-rhtap-values.yaml
@@ -136,7 +136,10 @@ upstream:
       - name: NODE_OPTIONS
         value: --no-node-snapshot
       - name: BACKEND_SECRET
-        value: "{{ '{{ randAlphaNum 24 | b64enc }}' }}"
+        valueFrom:
+          secretKeyRef:
+            name: backstage-redhat-developer-hub-auth
+            key: backend-secret
       - name: 'APP_CONFIG_app_baseUrl'
         value: 'https://{{ ocp4_workload_trusted_application_pipeline_backstage_host }}'
       - name: 'APP_CONFIG_backend_baseUrl'
@@ -203,6 +206,14 @@ upstream:
 
     appConfig:
       backend:
+{% if ocp4_workload_redhat_developer_hub_orchestrator_enabled %}
+        auth:
+          externalAccess:
+            - type: static
+              options:
+                token: ${BACKEND_SECRET}
+                subject: orchestrator
+{% endif %}
         listen:
           port: 7007
           host: 0.0.0.0
@@ -276,13 +287,6 @@ upstream:
         environment: production
         providers:
           oauth2Proxy: {}
-{% if ocp4_workload_redhat_developer_hub_orchestrator_enabled %}
-        externalAccess:
-          - type: static
-            options:
-              token: h5nbpC9Vgnp7uoQ3HkMDoa0ep2mjiV2D
-              subject: orchestrator
-{% endif %}
 
       signInPage: oauth2Proxy
 

--- a/charts/backstage/templates/backstage-internal.service.yaml
+++ b/charts/backstage/templates/backstage-internal.service.yaml
@@ -1,0 +1,16 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: backstage-internal
+  namespace: backstage
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 7007
+  internalTrafficPolicy: Cluster
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/component: backstage
+    app.kubernetes.io/instance: backstage
+    app.kubernetes.io/name: developer-hub


### PR DESCRIPTION
Moves the backend authentication to the correct location in the Backstage config, and uses a value from a secret for easier integration with Sonataflow